### PR TITLE
hotfix: la segunda es la vencida

### DIFF
--- a/src/components/ui/combobox.tsx
+++ b/src/components/ui/combobox.tsx
@@ -85,8 +85,7 @@ export function Combobox({
           side="bottom"
           align="start"
           sideOffset={4}
-          avoidCollisions={true}
-          collisionPadding={8}
+          avoidCollisions={false}
         >
           <Command>
             <CommandInput placeholder={searchPlaceholder} />


### PR DESCRIPTION
This pull request makes a small adjustment to the `Combobox` component in `src/components/ui/combobox.tsx`. The change disables collision avoidance by setting `avoidCollisions` to `false` and removes the `collisionPadding` property, likely to modify how the dropdown behaves in constrained layouts.