### PR TITLE
feat: add theme initialization script to support dark and high contra…

### DIFF
--- a/src/layouts/MainHead.astro
+++ b/src/layouts/MainHead.astro
@@ -15,6 +15,28 @@ const { title, description, image, frontmatter, robots } = Astro.props;
   <meta name="description" content={description} />
 
   <ClientRouter />
+  
+  <!-- Theme initialization script to prevent flash of light mode -->
+  <script>
+    (function() {
+      // Check user preferences immediately
+      const savedDarkTheme = localStorage.getItem("dark-theme");
+      const savedHighContrast = localStorage.getItem("high-contrast");
+      const prefersDarkTheme = window.matchMedia("(prefers-color-scheme: dark)").matches;
+      const prefersHighContrast = window.matchMedia("(prefers-contrast: high)").matches;
+      
+      // Apply dark theme if needed
+      if (savedDarkTheme === "true" || (savedDarkTheme === null && prefersDarkTheme)) {
+        document.documentElement.classList.add("dark");
+      }
+      
+      // Apply high contrast if needed
+      if (savedHighContrast === "true" || (savedHighContrast === null && prefersHighContrast)) {
+        document.documentElement.classList.add("high-contrast");
+      }
+    })();
+  </script>
+  
   <!-- Cloudflare Web Analytics -->
   <script
     defer


### PR DESCRIPTION
This pull request introduces a client-side script to initialize user interface themes (dark mode and high contrast) based on user preferences or system settings. This change aims to prevent a flash of light mode during page load.

### Theme Initialization:
* Added a script in `src/layouts/MainHead.astro` to check and apply user preferences for dark mode and high contrast. The script uses `localStorage` to retrieve saved preferences and falls back to system settings if no preferences are saved. It applies the appropriate CSS classes (`dark` and `high-contrast`) to the `document.documentElement` to ensure a seamless user experience.…st modes