### PR TITLE
Feat: Sortear por positividad de reseñas

### DIFF
--- a/src/components/features/courses/ReviewSort.tsx
+++ b/src/components/features/courses/ReviewSort.tsx
@@ -1,0 +1,23 @@
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+
+interface ReviewSortProps {
+  currentSort: string;
+  onSortChange: (sortBy: string) => void;
+}
+
+export function ReviewSort({ currentSort, onSortChange }: ReviewSortProps) {
+  return (
+    <div className="flex items-center gap-2">
+      <span className="text-sm text-muted-foreground">Ordenar por:</span>
+      <Select value={currentSort} onValueChange={onSortChange}>
+        <SelectTrigger size="sm" className="w-fit">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="recent">Más recientes</SelectItem>
+          <SelectItem value="positivity">Más positivas</SelectItem>
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}

--- a/src/components/table/columns.tsx
+++ b/src/components/table/columns.tsx
@@ -151,8 +151,36 @@ export const columns: ColumnDef<Course>[] = [
   },
   {
     accessorKey: "reviews",
-    header: () => {
-      return <div className="text-left font-semibold">Reseñas</div>;
+    header: ({ column }) => {
+      return (
+        <Button
+          className="font-semibold flex gap-2 items-center my-2"
+          variant="ghost"
+          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+        >
+          Reseñas
+          <SwapVertIcon />
+        </Button>
+      );
+    },
+    sortingFn: (rowA, rowB) => {
+      const a = rowA.original;
+      const b = rowB.original;
+      
+      // Calculate positivity percentage for both rows
+      const positivityA = calculatePositivePercentage(a.likes, a.superlikes, a.dislikes);
+      const positivityB = calculatePositivePercentage(b.likes, b.superlikes, b.dislikes);
+      
+      // Primary sort: by positivity percentage
+      if (positivityA !== positivityB) {
+        return positivityA - positivityB;
+      }
+      
+      // Secondary sort: by total review count (more reviews = higher rank)
+      const totalA = a.likes + a.superlikes + a.dislikes;
+      const totalB = b.likes + b.superlikes + b.dislikes;
+      
+      return totalA - totalB;
     },
     cell: ({ row }) => {
       const { superlikes, likes, dislikes } = row.original;

--- a/src/lib/courseStats.ts
+++ b/src/lib/courseStats.ts
@@ -63,3 +63,10 @@ export function getSentimentLabel(sentiment: string): string {
   };
   return labels[sentiment as keyof typeof labels] || "Sin datos";
 }
+
+export function calculateReviewPositivity(like_dislike: number): number {
+  // like_dislike: 0 = dislike, 1 = like, 2 = superlike
+  if (like_dislike === 2) return 100; // superlike = 100%
+  if (like_dislike === 1) return 75;  // like = 75% 
+  return 0; // dislike = 0%
+}

--- a/src/lib/server/courses.ts
+++ b/src/lib/server/courses.ts
@@ -24,7 +24,14 @@ export const getCourseBySigle = async (locals: App.Locals, sigle: string) => {
   return result.results[0] ?? null;
 };
 
-export const getCourseReviews = async (locals: App.Locals, sigle: string, limit: number = 20) => {
+export const getCourseReviews = async (locals: App.Locals, sigle: string, limit: number = 20, sortBy: 'recent' | 'positivity' = 'recent') => {
+  let orderClause = 'ORDER BY updated_at DESC';
+  
+  if (sortBy === 'positivity') {
+    // Sort by positivity: superlikes (2) first, then likes (1), then dislikes (0)
+    orderClause = 'ORDER BY like_dislike DESC, updated_at DESC';
+  }
+  
   const result = await locals.runtime.env.DB.prepare(`
     SELECT 
       id,
@@ -41,7 +48,7 @@ export const getCourseReviews = async (locals: App.Locals, sigle: string, limit:
       updated_at
     FROM course_reviews 
     WHERE course_sigle = ? AND status != 3
-    ORDER BY updated_at DESC
+    ${orderClause}
     LIMIT ?
   `).bind(sigle, limit).all<CourseReview>()
 

--- a/src/pages/[sigle]/index.astro
+++ b/src/pages/[sigle]/index.astro
@@ -48,6 +48,7 @@ import { getToken } from "@/lib/auth";
 import PrerequisitesSection from "@/components/features/courses/PrerequisitesSection";
 import SectionsCollapsible from "@/components/features/courses/SectionsCollapsible";
 import CourseCampuses from "@/components/features/courses/CourseCampuses";
+import { ReviewSort } from "@/components/features/courses/ReviewSort";
 
 const courseData = await getEntry("coursesStatic", sigle);
 if (!courseData) {
@@ -56,7 +57,10 @@ if (!courseData) {
 const course = courseData.data;
 
 const c = await getCourseBySigle(Astro.locals, sigle);
-const reviews = await getCourseReviews(Astro.locals, sigle, 10);
+
+// Get sort parameter from URL
+const sortBy = Astro.url.searchParams.get('sort') as 'recent' | 'positivity' || 'recent';
+const reviews = await getCourseReviews(Astro.locals, sigle, 10, sortBy);
 
 // Get prerequisites with names
 const prerequisites = await getPrerequisitesWithNames(course.req);
@@ -352,6 +356,19 @@ const successMessage = Astro.url.searchParams.get('success');
                             )}
                         </div>
                     </div>
+                    {reviews && reviews.length > 0 && (
+                        <div class="mt-4 flex justify-end">
+                            <ReviewSort 
+                                currentSort={sortBy} 
+                                onSortChange={(newSort) => {
+                                    const url = new URL(window.location.href);
+                                    url.searchParams.set('sort', newSort);
+                                    window.location.href = url.toString();
+                                }}
+                                client:load
+                            />
+                        </div>
+                    )}
                 </div>
 
                 {reviews && reviews.length > 0 ? (


### PR DESCRIPTION
This pull request introduces a new feature that allows users to sort course reviews by either recency or positivity. It includes changes to the frontend, backend, and utility functions to support this functionality.

### Frontend Changes:
* Added a new `ReviewSort` component in `src/components/features/courses/ReviewSort.tsx` to provide a dropdown for selecting the sorting option. Users can choose between "Más recientes" (most recent) and "Más positivas" (most positive).
* Updated `src/pages/[sigle]/index.astro` to integrate the `ReviewSort` component, retrieve the sort parameter from the URL, and pass it to the backend when fetching reviews. The sorting option is dynamically updated in the URL when the user selects a new sort order. ([src/pages/[sigle]/index.astroR51](diffhunk://#diff-6f6aa08f2d0e3b0d212a91ea6f41561ca98821a1a71512cbe9808d12b4efc250R51), [src/pages/[sigle]/index.astroL59-R63](diffhunk://#diff-6f6aa08f2d0e3b0d212a91ea6f41561ca98821a1a71512cbe9808d12b4efc250L59-R63), [src/pages/[sigle]/index.astroR359-R371](diffhunk://#diff-6f6aa08f2d0e3b0d212a91ea6f41561ca98821a1a71512cbe9808d12b4efc250R359-R371))
* Enhanced the `reviews` column in `src/components/table/columns.tsx` to include a sortable header. Sorting now prioritizes positivity percentage, with a secondary sort by total review count.

### Backend Changes:
* Modified the `getCourseReviews` function in `src/lib/server/courses.ts` to accept a `sortBy` parameter (`'recent'` or `'positivity'`) and adjust the SQL query accordingly. Reviews can now be sorted by recency or positivity. [[1]](diffhunk://#diff-fd99a9ba8a7cb12999ba3db99438c44465df3ffc9b669efab1d23bece712b097L27-R34) [[2]](diffhunk://#diff-fd99a9ba8a7cb12999ba3db99438c44465df3ffc9b669efab1d23bece712b097L44-R51)

### Utility Changes:
* Added a new `calculateReviewPositivity` function in `src/lib/courseStats.ts` to calculate positivity percentages based on review types (dislike, like, superlike). This is used for sorting reviews by positivity.