### PR TITLE
hotfix: Quitar filtros de reviews en sigle/index

### DIFF
--- a/src/pages/[sigle]/index.astro
+++ b/src/pages/[sigle]/index.astro
@@ -48,7 +48,6 @@ import { getToken } from "@/lib/auth";
 import PrerequisitesSection from "@/components/features/courses/PrerequisitesSection";
 import SectionsCollapsible from "@/components/features/courses/SectionsCollapsible";
 import CourseCampuses from "@/components/features/courses/CourseCampuses";
-import { ReviewSort } from "@/components/features/courses/ReviewSort";
 
 const courseData = await getEntry("coursesStatic", sigle);
 if (!courseData) {
@@ -57,10 +56,7 @@ if (!courseData) {
 const course = courseData.data;
 
 const c = await getCourseBySigle(Astro.locals, sigle);
-
-// Get sort parameter from URL
-const sortBy = Astro.url.searchParams.get('sort') as 'recent' | 'positivity' || 'recent';
-const reviews = await getCourseReviews(Astro.locals, sigle, 10, sortBy);
+const reviews = await getCourseReviews(Astro.locals, sigle, 10);
 
 // Get prerequisites with names
 const prerequisites = await getPrerequisitesWithNames(course.req);
@@ -356,19 +352,6 @@ const successMessage = Astro.url.searchParams.get('success');
                             )}
                         </div>
                     </div>
-                    {reviews && reviews.length > 0 && (
-                        <div class="mt-4 flex justify-end">
-                            <ReviewSort 
-                                currentSort={sortBy} 
-                                onSortChange={(newSort) => {
-                                    const url = new URL(window.location.href);
-                                    url.searchParams.set('sort', newSort);
-                                    window.location.href = url.toString();
-                                }}
-                                client:load
-                            />
-                        </div>
-                    )}
                 </div>
 
                 {reviews && reviews.length > 0 ? (


### PR DESCRIPTION
This pull request simplifies the `src/pages/[sigle]/index.astro` file by removing the review sorting functionality, including the associated UI component and URL parameter handling. The changes streamline the code and reduce complexity by focusing on a single default sorting behavior for course reviews.

### Removal of review sorting functionality:

* Removed the import for the `ReviewSort` component, as it is no longer used in the file. (`[src/pages/[sigle]/index.astroL51](diffhunk://#diff-6f6aa08f2d0e3b0d212a91ea6f41561ca98821a1a71512cbe9808d12b4efc250L51)`)
* Eliminated the logic for retrieving the `sort` parameter from the URL and passing it to the `getCourseReviews` function. The reviews are now fetched with a default sorting behavior. (`[src/pages/[sigle]/index.astroL60-R59](diffhunk://#diff-6f6aa08f2d0e3b0d212a91ea6f41561ca98821a1a71512cbe9808d12b4efc250L60-R59)`)
* Deleted the `ReviewSort` component from the UI, along with its associated logic for handling user interactions and updating the URL. (`[src/pages/[sigle]/index.astroL359-L371](diffhunk://#diff-6f6aa08f2d0e3b0d212a91ea6f41561ca98821a1a71512cbe9808d12b4efc250L359-L371)`)