### PR TITLE
fix: update support links in footer to use email addresses

### DIFF
--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -43,9 +43,9 @@
       <div class="flex flex-col space-y-3">
         <h3 class="text-sm font-medium text-foreground">Soporte</h4>
         <ul class="space-y-2">
-          <li><a href="#" class="text-sm text-muted-foreground hover:text-foreground transition-colors">Ayuda</a></li>
-          <li><a href="#" class="text-sm text-muted-foreground hover:text-foreground transition-colors">Contacto</a></li>
-          <li><a href="#" class="text-sm text-muted-foreground hover:text-foreground transition-colors hidden">FAQ</a></li>
+          <li><a href="mailto:help@osuc.dev" class="text-sm text-muted-foreground hover:text-foreground transition-colors">Ayuda</a></li>
+          <li><a href="mailto:contact@osuc.dev" class="text-sm text-muted-foreground hover:text-foreground transition-colors">Contacto</a></li>
+          <li><a href="mailto:feedback@osuc.dev" class="text-sm text-muted-foreground hover:text-foreground transition-colors">Feedback</a></li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
This pull request updates the footer component in the `src/components/layout/Footer.astro` file to improve support contact options.

Key changes:

* Updated the "Ayuda" and "Contacto" links to use `mailto` links with specific email addresses (`help@osuc.dev` and `contact@osuc.dev`).
* Replaced the hidden "FAQ" link with a new "Feedback" link that uses a `mailto` link to `feedback@osuc.dev`.