### PR TITLE
2025-2

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -29,14 +29,14 @@ const {
     <CommandWrapper client:load>
       <!-- Banner de Anuncios -->
       <Banner
-        variant="green"
+        variant="pink"
         size="md"
         icon="VeryHappyIcon"
         dismissible={true}
-        bannerId="2025-07-14"
+        bannerId="2025-07-15"
         client:load
       >
-        <strong>¡Hoy se liberan los cursos del segundo semestre!</strong>: Anunciaremos por este medio cuando estén disponibles en la plataforma.
+        <strong>¡Actualizado con los cursos del segundo semestre!</strong>: Explora ramos, revisa sus reseñas y crea tu horario ideal. 
       </Banner>
 
       <!-- Main -->

--- a/src/lib/currentSemester.ts
+++ b/src/lib/currentSemester.ts
@@ -2,7 +2,7 @@
  * Semestre actual
  * Se debe actualizar al inicio de cada semestre
  */
-export const CURRENT_SEMESTER = "2025-1";
+export const CURRENT_SEMESTER = "2025-2";
 
 /**
  * Chequea si el semestre dado es el semestre actual

--- a/src/pages/[sigle]/index.astro
+++ b/src/pages/[sigle]/index.astro
@@ -49,6 +49,8 @@ import PrerequisitesSection from "@/components/features/courses/PrerequisitesSec
 import SectionsCollapsible from "@/components/features/courses/SectionsCollapsible";
 import CourseCampuses from "@/components/features/courses/CourseCampuses";
 
+import { CURRENT_SEMESTER } from "@/lib/currentSemester"
+
 const courseData = await getEntry("coursesStatic", sigle);
 if (!courseData) {
     return Astro.redirect("/404");
@@ -292,7 +294,7 @@ const successMessage = Astro.url.searchParams.get('success');
                 <div class="grid grid-cols-1 tablet:grid-cols-2 gap-4">
                     <Button
                         variant="outline"
-                        href={`https://buscacursos.uc.cl/?cxml_semestre=2025-1&cxml_sigla=${course.sigle}&cxml_nrc=&cxml_nombre=&cxml_categoria=TODOS&cxml_area_fg=TODOS&cxml_formato_cur=TODOS&cxml_profesor=&cxml_campus=TODOS&cxml_unidad_academica=TODOS&cxml_horario_tipo_busqueda=si_tenga&cxml_horario_tipo_busqueda_actividad=TODOS&cxml_periodo=TODOS&cxml_escuela=TODOS&cxml_nivel=TODOS#resultados`}
+                        href={`https://buscacursos.uc.cl/?cxml_semestre=${CURRENT_SEMESTER}&cxml_sigla=${course.sigle}&cxml_nrc=&cxml_nombre=&cxml_categoria=TODOS&cxml_area_fg=TODOS&cxml_formato_cur=TODOS&cxml_profesor=&cxml_campus=TODOS&cxml_unidad_academica=TODOS&cxml_horario_tipo_busqueda=si_tenga&cxml_horario_tipo_busqueda_actividad=TODOS&cxml_periodo=TODOS&cxml_escuela=TODOS&cxml_nivel=TODOS#resultados`}
                         target="_blank"
                         rel="noopener noreferrer"
                         className="w-full"


### PR DESCRIPTION
This pull request updates the application to reflect the start of the second semester of 2025. The changes include updating the current semester constant, modifying the announcement banner, and ensuring dynamic semester data is used across the site.

### Semester Updates:

* Updated the `CURRENT_SEMESTER` constant in `src/lib/currentSemester.ts` to reflect the new semester (`2025-2`). This ensures semester-dependent features are aligned with the current academic period.

* Replaced hardcoded semester data in the course search URL with the `CURRENT_SEMESTER` constant in `src/pages/[sigle]/index.astro`. This makes the application more dynamic and reduces the need for manual updates. ([src/pages/[sigle]/index.astroL295-R297](diffhunk://#diff-6f6aa08f2d0e3b0d212a91ea6f41561ca98821a1a71512cbe9808d12b4efc250L295-R297))

### Announcement Banner:

* Updated the announcement banner in `src/layouts/Layout.astro` with a new variant color (`pink`), a new banner ID (`2025-07-15`), and revised text to reflect the availability of second-semester courses.

### Codebase Enhancements:

* Imported the `CURRENT_SEMESTER` constant into `src/pages/[sigle]/index.astro` to enable its use in dynamic semester-related features. ([src/pages/[sigle]/index.astroR52-R53](diffhunk://#diff-6f6aa08f2d0e3b0d212a91ea6f41561ca98821a1a71512cbe9808d12b4efc250R52-R53))